### PR TITLE
Add repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "node-red-contrib-countula",
   "version": "1.1.9",
   "description": "Counts messages",
+  "repository": {
+        "type": "git",
+        "url": "https://github.com/protocolus/node-red-contrib-countula.git"
+    },
   "node-red" : {
         "nodes": {
             "countula": "countula.js"


### PR DESCRIPTION
adding the repo to the package.json will then create a link to it on flows.nodered.org and makes it easier to programatically locate the repo when crawling nodes.